### PR TITLE
Added config options to set number of extra lines or use a relative size

### DIFF
--- a/lib/overscroll.coffee
+++ b/lib/overscroll.coffee
@@ -1,6 +1,18 @@
 {CompositeDisposable} = require 'atom'
 
 module.exports = Overscroll =
+  config:
+    numOfLines:
+      title: 'Number of Lines'
+      description: 'Number of extra lines to show at the bottom'
+      type: 'integer'
+      default: 50
+    percent:
+      title: 'Relative Percent'
+      description: 'If set, will adjust size based on size of editor'
+      type: 'number'
+      default: 0
+
   activate: (state) ->
     @cd = new CompositeDisposable
 
@@ -11,7 +23,11 @@ module.exports = Overscroll =
         lineHeight = @getLineHeightInPixels()
         return 0 unless lineHeight > 0
 
-        scrollHeight = (50 + @getLineCount()) * lineHeight
+        percent = atom.config.get('overscroll.percent')
+        if percent
+          return @getHeight() * percent
+
+        scrollHeight = (atom.config.get('overscroll.numOfLines') + @getLineCount()) * lineHeight
         if @height? and @configSettings.scrollPastEnd
           scrollHeight = scrollHeight + @height - (lineHeight * 3)
 


### PR DESCRIPTION
I really like this module but decided it might be nice to have a little more configuration options available. With this, you can either specify a number of lines to add or a relative amount compared to the size of the editor.
What do you think?
